### PR TITLE
Add basic bump subcommand

### DIFF
--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -14,6 +14,12 @@ type Changelog struct {
 	Versions []*Version
 }
 
+// NewChangelog creates the changelog struct
+func NewChangelog() *Changelog {
+	c := Changelog{}
+	return &c
+}
+
 // Version finds and returns the version `v`
 // The search is case-insensitive
 func (c *Changelog) Version(version string) *Version {

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -26,6 +26,26 @@ func (c *Changelog) Version(version string) *Version {
 	return nil
 }
 
+// Release transforms Unreleased into the version informed
+func (c *Changelog) Release(newVersion Version) *Version {
+	oldUnreleased := c.Version("Unreleased")
+	prevVersion := c.Versions[len(c.Versions)-1]
+
+	newUnreleased := Version{
+		Name: "Unreleased",
+		Link: strings.Replace(oldUnreleased.Link, prevVersion.Name, newVersion.Name, -1),
+	}
+
+	oldUnreleased.Link = strings.Replace(oldUnreleased.Link, "HEAD", newVersion.Name, -1)
+
+	oldUnreleased.Name = newVersion.Name
+	oldUnreleased.Date = newVersion.Date
+
+	c.Versions = append([]*Version{&newUnreleased}, c.Versions...)
+
+	return oldUnreleased
+}
+
 // RenderLinks will render the links for each version
 func (c *Changelog) RenderLinks(w io.Writer) {
 	for _, v := range c.Versions {

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -33,23 +33,30 @@ func (c *Changelog) Version(version string) *Version {
 }
 
 // Release transforms Unreleased into the version informed
-func (c *Changelog) Release(newVersion Version) *Version {
+func (c *Changelog) Release(newVersion Version) (*Version, error) {
 	oldUnreleased := c.Version("Unreleased")
 	prevVersion := c.Versions[len(c.Versions)-1]
 
 	newUnreleased := Version{
 		Name: "Unreleased",
-		Link: strings.Replace(oldUnreleased.Link, prevVersion.Name, newVersion.Name, -1),
+	}
+
+	if newVersion.Link != "" {
+		newUnreleased.Link = strings.Replace(oldUnreleased.Link, prevVersion.Name, newVersion.Name, -1)
+	} else {
+		if prevVersion == oldUnreleased {
+			// we don't have a previous version
+			return nil, fmt.Errorf("Could not infer the compare link")
+		}
 	}
 
 	oldUnreleased.Link = strings.Replace(oldUnreleased.Link, "HEAD", newVersion.Name, -1)
-
 	oldUnreleased.Name = newVersion.Name
 	oldUnreleased.Date = newVersion.Date
 
 	c.Versions = append([]*Version{&newUnreleased}, c.Versions...)
 
-	return oldUnreleased
+	return oldUnreleased, nil
 }
 
 // RenderLinks will render the links for each version

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -35,7 +35,7 @@ func (c *Changelog) Version(version string) *Version {
 // Release transforms Unreleased into the version informed
 func (c *Changelog) Release(newVersion Version) (*Version, error) {
 	oldUnreleased := c.Version("Unreleased")
-	prevVersion := c.Versions[len(c.Versions)-1]
+	prevVersion := c.Versions[1]
 
 	newUnreleased := Version{
 		Name: "Unreleased",

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -41,14 +41,20 @@ func (c *Changelog) Release(newVersion Version) (*Version, error) {
 		Name: "Unreleased",
 	}
 
-	if newVersion.Link != "" {
-		newUnreleased.Link = strings.Replace(oldUnreleased.Link, prevVersion.Name, newVersion.Name, -1)
-	} else {
-		if prevVersion == oldUnreleased {
-			// we don't have a previous version
-			return nil, fmt.Errorf("Could not infer the compare link")
-		}
+	if prevVersion == oldUnreleased && newVersion.Link == "" {
+		// we don't have a previous version
+		return nil, fmt.Errorf("Could not infer the compare link")
 	}
+
+	var compareURL string
+	if newVersion.Link != "" {
+		compareURL = strings.Replace(newVersion.Link, "<prev>", newVersion.Name, -1)
+		compareURL = strings.Replace(compareURL, "<next>", "HEAD", -1)
+	} else {
+		compareURL = strings.Replace(oldUnreleased.Link, prevVersion.Name, newVersion.Name, -1)
+	}
+
+	newUnreleased.Link = compareURL
 
 	oldUnreleased.Link = strings.Replace(oldUnreleased.Link, "HEAD", newVersion.Name, -1)
 	oldUnreleased.Name = newVersion.Name

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -59,12 +59,26 @@ func TestChangelogRelease(t *testing.T) {
 		},
 	}
 
-	newVersion, err := c.Release(Version{Name: "2.0.0"})
+	t.Run("default", func(t *testing.T) {
+		newVersion, err := c.Release(Version{Name: "2.0.0"})
 
-	assert.Nil(t, err)
-	assert.Equal(t, "2.0.0", newVersion.Name)
-	// Make sure the changes were kept
-	assert.Equal(t, 1, len(newVersion.Changes))
+		assert.Nil(t, err)
+		assert.Equal(t, "2.0.0", newVersion.Name)
+		// Make sure the changes were kept
+		assert.Equal(t, 1, len(newVersion.Changes))
+	})
+
+	t.Run("explicit-compare-url", func(t *testing.T) {
+		v := Version{Name: "2.0.0", Link: "https://localhost/<prev>..<next>"}
+		newVersion, err := c.Release(v)
+
+		assert.Equal(t, "2.0.0", newVersion.Name)
+
+		unreleased := c.Version("Unreleased")
+		assert.Equal(t, "https://localhost/2.0.0..HEAD", unreleased.Link)
+
+		assert.Nil(t, err)
+	})
 }
 
 func TestChangelogRenderLinks(t *testing.T) {

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -59,8 +59,9 @@ func TestChangelogRelease(t *testing.T) {
 		},
 	}
 
-	newVersion := c.Release(Version{Name: "2.0.0"})
+	newVersion, err := c.Release(Version{Name: "2.0.0"})
 
+	assert.Nil(t, err)
 	assert.Equal(t, "2.0.0", newVersion.Name)
 	// Make sure the changes were kept
 	assert.Equal(t, 1, len(newVersion.Changes))

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -3,6 +3,8 @@ package chg
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChangelogVersion(t *testing.T) {
@@ -33,6 +35,35 @@ func TestChangelogVersion(t *testing.T) {
 			t.Error("Test comparing 'unknown' version failed")
 		}
 	})
+}
+
+func TestChangelogRelease(t *testing.T) {
+	c := Changelog{
+		Versions: []*Version{
+			{
+				Name: "Unreleased",
+				Link: "http://example.com/1.0.0..HEAD",
+				Changes: []*ChangeList{
+					{
+						Type: Added,
+						Items: []*Item{
+							{Description: "New feature"},
+						},
+					},
+				},
+			},
+			{
+				Name: "1.0.0",
+				Link: "http://example.com/abcdef..1.0.0",
+			},
+		},
+	}
+
+	newVersion := c.Release(Version{Name: "2.0.0"})
+
+	assert.Equal(t, "2.0.0", newVersion.Name)
+	// Make sure the changes were kept
+	assert.Equal(t, 1, len(newVersion.Changes))
 }
 
 func TestChangelogRenderLinks(t *testing.T) {

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -11,7 +11,7 @@ func TestChangelogVersion(t *testing.T) {
 	unreleased := &Version{Name: "Unreleased"}
 	v123 := &Version{Name: "1.2.3"}
 
-	c := Changelog{}
+	c := NewChangelog()
 	c.Versions = append(c.Versions, unreleased)
 	c.Versions = append(c.Versions, v123)
 
@@ -71,7 +71,7 @@ func TestChangelogRenderLinks(t *testing.T) {
 	v123 := &Version{Name: "1.2.3", Link: "http://example.com/1.2.3"}
 	v456 := &Version{Name: "4.5.6"}
 
-	c := Changelog{}
+	c := NewChangelog()
 	c.Versions = append(c.Versions, unreleased)
 	c.Versions = append(c.Versions, v123)
 	c.Versions = append(c.Versions, v456)

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -56,6 +56,10 @@ func TestChangelogRelease(t *testing.T) {
 				Name: "1.0.0",
 				Link: "http://example.com/abcdef..1.0.0",
 			},
+			{
+				Name: "0.2.0",
+				Link: "http://example.com/abcdef..0.2.0",
+			},
 		},
 	}
 

--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -13,6 +13,7 @@ import (
 const dateFormat = "2006-01-02"
 
 var releaseDate string
+var compareURL string
 
 var bumpCmd = &cobra.Command{
 	Use:   "bump",
@@ -31,6 +32,10 @@ var bumpCmd = &cobra.Command{
 			Date: releaseDate,
 		}
 
+		if compareURL != "" {
+			version.Link = compareURL
+		}
+
 		changelog := parser.Parse(input)
 		_, err = changelog.Release(version)
 		if err != nil {
@@ -45,5 +50,6 @@ var bumpCmd = &cobra.Command{
 func init() {
 	today := time.Now().Format(dateFormat)
 	bumpCmd.Flags().StringVarP(&releaseDate, "release-date", "d", today, "")
+	bumpCmd.Flags().StringVarP(&compareURL, "compare-url", "c", "", "Overwrite compare URL for Unreleased section")
 	rootCmd.AddCommand(bumpCmd)
 }

--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -32,7 +32,12 @@ var bumpCmd = &cobra.Command{
 		}
 
 		changelog := parser.Parse(input)
-		changelog.Release(version)
+		_, err = changelog.Release(version)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to bump version to %s: %s\n", args[0], err)
+			os.Exit(3)
+		}
+
 		changelog.Render(os.Stdout)
 	},
 }

--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rcmachado/changelog/chg"
+	"github.com/rcmachado/changelog/parser"
+	"github.com/spf13/cobra"
+)
+
+const dateFormat = "2006-01-02"
+
+var releaseDate string
+
+var bumpCmd = &cobra.Command{
+	Use:   "bump",
+	Short: "Bump version on changelog",
+	Long:  "Change current Unreleased version into the new version",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		input, err := readChangelog(filename)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(2)
+		}
+
+		version := chg.Version{
+			Name: args[0],
+			Date: releaseDate,
+		}
+
+		changelog := parser.Parse(input)
+		changelog.Release(version)
+		changelog.Render(os.Stdout)
+	},
+}
+
+func init() {
+	today := time.Now().Format(dateFormat)
+	bumpCmd.Flags().StringVarP(&releaseDate, "release-date", "d", today, "")
+	rootCmd.AddCommand(bumpCmd)
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -23,7 +23,7 @@ func Parse(input []byte) *chg.Changelog {
 
 func newRenderer() renderer {
 	r := renderer{}
-	r.changelog = &chg.Changelog{}
+	r.changelog = chg.NewChangelog()
 	r.reVersion = regexp.MustCompile(`(?i)\[?(?P<name>[0-9a-zA-Z\-\.]+)\]?(?: - (?P<date>[0-9a-z\-\.]+))?(?P<yanked> \[YANKED\])?`)
 	return r
 }


### PR DESCRIPTION
Add `bump` subcommmand that transform the current `Unreleased` into the new version.

Given enough versions, it will infer the compare link.

- [x] Add option to pass a custom date
- [x] Fail graceful if we're not able to infer the compare URL
- [x] Add option to receive a compare URL

Fixes #4.