### PR TITLE
Refactor tests to use stretchr/testify assert library

### DIFF
--- a/chg/change_test.go
+++ b/chg/change_test.go
@@ -2,53 +2,33 @@ package chg
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewChangeList(t *testing.T) {
-	t.Run("type=added", func(t *testing.T) {
-		result := NewChangeList("Added")
+	var testData = []struct {
+		input    string
+		expected ChangeType
+	}{
+		{input: "Added", expected: Added},
+		{input: "Changed", expected: Changed},
+		{input: "Deprecated", expected: Deprecated},
+		{input: "Fixed", expected: Fixed},
+		{input: "Removed", expected: Removed},
+		{input: "Security", expected: Security},
+	}
 
-		assert.NotNil(t, result)
-		assert.Equal(t, Added, result.Type)
-	})
+	for _, tt := range testData {
+		t.Run(fmt.Sprintf("type=%s", tt.input), func(t *testing.T) {
+			result := NewChangeList(tt.input)
 
-	t.Run("type=changed", func(t *testing.T) {
-		result := NewChangeList("Changed")
-
-		assert.NotNil(t, result)
-		assert.Equal(t, Changed, result.Type)
-	})
-
-	t.Run("type=deprecated", func(t *testing.T) {
-		result := NewChangeList("Deprecated")
-
-		assert.NotNil(t, result)
-		assert.Equal(t, Deprecated, result.Type)
-	})
-
-	t.Run("type=fixed", func(t *testing.T) {
-		result := NewChangeList("Fixed")
-
-		assert.NotNil(t, result)
-		assert.Equal(t, Fixed, result.Type)
-	})
-
-	t.Run("type=removed", func(t *testing.T) {
-		result := NewChangeList("Removed")
-
-		assert.NotNil(t, result)
-		assert.Equal(t, Removed, result.Type)
-	})
-
-	t.Run("type=security", func(t *testing.T) {
-		result := NewChangeList("Security")
-
-		assert.NotNil(t, result)
-		assert.Equal(t, Security, result.Type)
-	})
+			assert.NotNil(t, result)
+			assert.Equal(t, tt.expected, result.Type)
+		})
+	}
 
 	t.Run("type=unknown", func(t *testing.T) {
 		result := NewChangeList("unknown")

--- a/chg/change_test.go
+++ b/chg/change_test.go
@@ -3,56 +3,57 @@ package chg
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewChangeList(t *testing.T) {
 	t.Run("type=added", func(t *testing.T) {
 		result := NewChangeList("Added")
-		if result == nil || result.Type != Added {
-			t.Errorf("NewChangeList failed expected Added got %s", result)
-		}
+
+		assert.NotNil(t, result)
+		assert.Equal(t, Added, result.Type)
 	})
 
 	t.Run("type=changed", func(t *testing.T) {
 		result := NewChangeList("Changed")
-		if result == nil || result.Type != Changed {
-			t.Errorf("NewChangeList failed expected Changed got %s", result)
-		}
+
+		assert.NotNil(t, result)
+		assert.Equal(t, Changed, result.Type)
 	})
 
 	t.Run("type=deprecated", func(t *testing.T) {
 		result := NewChangeList("Deprecated")
-		if result == nil || result.Type != Deprecated {
-			t.Errorf("NewChangeList failed expected Deprecated got %s", result)
-		}
+
+		assert.NotNil(t, result)
+		assert.Equal(t, Deprecated, result.Type)
 	})
 
 	t.Run("type=fixed", func(t *testing.T) {
 		result := NewChangeList("Fixed")
-		if result == nil || result.Type != Fixed {
-			t.Errorf("NewChangeList failed expected Fixed got %s", result)
-		}
+
+		assert.NotNil(t, result)
+		assert.Equal(t, Fixed, result.Type)
 	})
 
 	t.Run("type=removed", func(t *testing.T) {
 		result := NewChangeList("Removed")
-		if result == nil || result.Type != Removed {
-			t.Errorf("NewChangeList failed expected Removed got %s", result)
-		}
+
+		assert.NotNil(t, result)
+		assert.Equal(t, Removed, result.Type)
 	})
 
 	t.Run("type=security", func(t *testing.T) {
 		result := NewChangeList("Security")
-		if result == nil || result.Type != Security {
-			t.Errorf("NewChangeList failed expected Security got %s", result)
-		}
+
+		assert.NotNil(t, result)
+		assert.Equal(t, Security, result.Type)
 	})
 
 	t.Run("type=unknown", func(t *testing.T) {
 		result := NewChangeList("unknown")
-		if result != nil {
-			t.Errorf("NewChangeList failed expected nil got %s", result)
-		}
+
+		assert.Nil(t, result)
 	})
 }
 
@@ -73,9 +74,7 @@ func TestChangeListRenderItems(t *testing.T) {
 	c.RenderItems(&buf)
 	result := buf.String()
 
-	if result != expected {
-		t.Errorf("ChangeList.RenderItems failed, expected %s got %s", expected, result)
-	}
+	assert.Equal(t, expected, result)
 }
 
 func TestChangeRender(t *testing.T) {
@@ -91,7 +90,6 @@ func TestChangeRender(t *testing.T) {
 	var buf bytes.Buffer
 	c.Render(&buf)
 	result := string(buf.Bytes())
-	if result != expected {
-		t.Errorf("Render failed, expected %s got %s", expected, result)
-	}
+
+	assert.Equal(t, expected, result)
 }

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -17,23 +17,17 @@ func TestChangelogVersion(t *testing.T) {
 
 	t.Run("version=unreleased", func(t *testing.T) {
 		result := c.Version("unreleased")
-		if result != unreleased {
-			t.Error("Test comparing 'unreleased' version failed")
-		}
+		assert.Equal(t, unreleased, result)
 	})
 
 	t.Run("version=1.2.3", func(t *testing.T) {
 		result := c.Version("1.2.3")
-		if result != v123 {
-			t.Error("Test comparing '1.2.3' version failed")
-		}
+		assert.Equal(t, v123, result)
 	})
 
 	t.Run("version=unknown", func(t *testing.T) {
 		result := c.Version("unknown")
-		if result != nil {
-			t.Error("Test comparing 'unknown' version failed")
-		}
+		assert.NotNil(t, result)
 	})
 }
 
@@ -101,9 +95,7 @@ func TestChangelogRenderLinks(t *testing.T) {
 	c.RenderLinks(&buf)
 	result := string(buf.Bytes())
 
-	if result != expected {
-		t.Errorf("TestChangelogRenderLinks fail, expecting %s found %s", expected, result)
-	}
+	assert.Equal(t, expected, result)
 }
 
 func TestChangelogRender(t *testing.T) {
@@ -116,9 +108,7 @@ func TestChangelogRender(t *testing.T) {
 		var buf bytes.Buffer
 		c.Render(&buf)
 		result := buf.String()
-		if result != expected {
-			t.Errorf("TestChangelogRender with empty versions fails, got %s expected %s", result, expected)
-		}
+		assert.Equal(t, expected, result)
 	})
 
 	t.Run("with-versions", func(t *testing.T) {
@@ -131,9 +121,7 @@ func TestChangelogRender(t *testing.T) {
 		var buf bytes.Buffer
 		c.Render(&buf)
 		result := buf.String()
-		if result != expected {
-			t.Errorf("TestChangelogRender with versions fails, got =%s= expected =%s=", result, expected)
-		}
+		assert.Equal(t, expected, result)
 	})
 
 	t.Run("sort-changes", func(t *testing.T) {
@@ -155,9 +143,6 @@ func TestChangelogRender(t *testing.T) {
 		var buf bytes.Buffer
 		c.Render(&buf)
 		result := buf.String()
-		if result != expected {
-			t.Errorf("TestChangelogRender with sorted changes fails, got =%s= expected =%s=", result, expected)
-		}
+		assert.Equal(t, expected, result)
 	})
-
 }

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -27,7 +27,7 @@ func TestChangelogVersion(t *testing.T) {
 
 	t.Run("version=unknown", func(t *testing.T) {
 		result := c.Version("unknown")
-		assert.NotNil(t, result)
+		assert.Nil(t, result)
 	})
 }
 

--- a/chg/item_test.go
+++ b/chg/item_test.go
@@ -3,6 +3,8 @@ package chg
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestItemRender(t *testing.T) {
@@ -13,7 +15,5 @@ func TestItemRender(t *testing.T) {
 	i.Render(&buf)
 	result := buf.String()
 
-	if result != expected {
-		t.Errorf("Item.Render failed, expected %s got %s", expected, result)
-	}
+	assert.Equal(t, expected, result)
 }

--- a/chg/version_test.go
+++ b/chg/version_test.go
@@ -2,8 +2,9 @@ package chg
 
 import (
 	"bytes"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSortChanges(t *testing.T) {
@@ -30,9 +31,7 @@ func TestSortChanges(t *testing.T) {
 
 	v.SortChanges()
 
-	if !reflect.DeepEqual(v.Changes, expected) {
-		t.Error("SortChanges should sort Changes properly")
-	}
+	assert.Equal(t, expected, v.Changes)
 }
 
 func TestChange(t *testing.T) {
@@ -49,16 +48,12 @@ func TestChange(t *testing.T) {
 
 	t.Run("change-exists", func(t *testing.T) {
 		result := v.Change(Added)
-		if result != added {
-			t.Errorf("Search for change, expected %s got %s", Added, result)
-		}
+		assert.Equal(t, added, result)
 	})
 
 	t.Run("change-does-not-exist", func(t *testing.T) {
 		result := v.Change(Security)
-		if result != nil {
-			t.Errorf("Search for unknown change, expected nil got %s", result)
-		}
+		assert.Nil(t, result)
 	})
 }
 
@@ -71,9 +66,7 @@ func TestRenderTitle(t *testing.T) {
 		var buf bytes.Buffer
 		v.RenderTitle(&buf)
 		result := string(buf.Bytes())
-		if expected != result {
-			t.Errorf("RenderTitle should render version only, expected %s, got %s", expected, result)
-		}
+		assert.Equal(t, expected, result)
 	})
 
 	t.Run("date", func(t *testing.T) {
@@ -85,9 +78,7 @@ func TestRenderTitle(t *testing.T) {
 		var buf bytes.Buffer
 		v.RenderTitle(&buf)
 		result := string(buf.Bytes())
-		if expected != result {
-			t.Errorf("RenderTitle should render the date, expected %s, got %s", expected, result)
-		}
+		assert.Equal(t, expected, result)
 	})
 
 	t.Run("link", func(t *testing.T) {
@@ -99,9 +90,7 @@ func TestRenderTitle(t *testing.T) {
 		var buf bytes.Buffer
 		v.RenderTitle(&buf)
 		result := string(buf.Bytes())
-		if expected != result {
-			t.Errorf("RenderTitle should render link, expected %s, got %s", expected, result)
-		}
+		assert.Equal(t, expected, result)
 	})
 
 	t.Run("yanked", func(t *testing.T) {
@@ -113,9 +102,7 @@ func TestRenderTitle(t *testing.T) {
 		var buf bytes.Buffer
 		v.RenderTitle(&buf)
 		result := string(buf.Bytes())
-		if expected != result {
-			t.Errorf("RenderTitle should render yanked versions, expected %s, got %s", expected, result)
-		}
+		assert.Equal(t, expected, result)
 	})
 }
 
@@ -152,9 +139,7 @@ func TestRenderChanges(t *testing.T) {
 	v.RenderChanges(&buf)
 	result := string(buf.Bytes())
 
-	if result != expected {
-		t.Errorf("RenderChanges fail, expected %s got %s", expected, result)
-	}
+	assert.Equal(t, expected, result)
 }
 
 func TestVersionRender(t *testing.T) {
@@ -191,7 +176,5 @@ func TestVersionRender(t *testing.T) {
 	v.Render(&buf)
 	result := string(buf.Bytes())
 
-	if result != expected {
-		t.Errorf("RenderChanges fail, expected %s got %s", expected, result)
-	}
+	assert.Equal(t, expected, result)
 }


### PR DESCRIPTION
This make tests more readable and easier to write.

Fixes #5.