### PR TITLE
Create Changelog releases automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ jobs:
           command: |
             curl --location -o goreleaser.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.77.2/goreleaser_Linux_x86_64.tar.gz
             tar xzf goreleaser.tar.gz goreleaser
-            ./goreleaser --snapshot
+            [[ "$CIRCLE_TAG" == "" ]] && OPTS="--snapshot"
+            ./goreleaser "$OPTS"
       - store_artifacts:
           path: dist
           destination: builds
@@ -43,4 +44,7 @@ workflows:
   build:
     jobs:
       - tests
-      - release
+      - release:
+          filters:
+            tags:
+              only: /\d+\.\d+\.\d+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,8 @@ workflows:
     jobs:
       - tests
       - release:
+          requires:
+            - tests
           filters:
             tags:
               only: /\d+\.\d+\.\d+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,11 @@ jobs:
     steps:
       - checkout
       - run: go get -v -t -d ./...
-      - run: go build
+      - run:
+          command: |
+            curl --location -o goreleaser.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.77.2/goreleaser_Linux_x86_64.tar.gz
+            tar xzf goreleaser.tar.gz goreleaser
+            ./goreleaser --snapshot
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
+
 jobs:
-  build:
+  tests:
     docker:
       - image: circleci/golang:1.10
     working_directory: /go/src/github.com/rcmachado/changelog
@@ -20,3 +21,19 @@ jobs:
           destination: raw-test-output
       - store_test_results:
           path: /tmp/test-results
+
+  release:
+    docker:
+      - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/rcmachado/changelog
+    steps:
+      - checkout
+      - run: go get -v -t -d ./...
+      - run: go build
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - tests
+      - release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
             curl --location -o goreleaser.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.77.2/goreleaser_Linux_x86_64.tar.gz
             tar xzf goreleaser.tar.gz goreleaser
             ./goreleaser --snapshot
+      - store_artifacts:
+          path: dist
+          destination: builds
 
 workflows:
   version: 2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,7 @@
+builds:
+  - binary: changelog
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64


### PR DESCRIPTION
Using the [goreleaser](https://goreleaser.com/) tool, create binaries for macOS and Linux (x86_64) automatically.

For tags, it will create and upload the binary to Github releases. Other branches will generate a binary and store it in CI artifacts.

Fixes #2.