### PR TITLE
Merge duplicated sections on changelog when parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Merge duplicated sections when parsing changelog file
 
 ## [0.1.0] - 2018-06-17
 ### Added

--- a/chg/change.go
+++ b/chg/change.go
@@ -21,7 +21,8 @@ type ChangeType int
 
 // Change types
 const (
-	Added ChangeType = iota
+	Unknown ChangeType = iota
+	Added
 	Changed
 	Deprecated
 	Fixed

--- a/chg/change.go
+++ b/chg/change.go
@@ -30,26 +30,33 @@ const (
 	Security
 )
 
-// NewChangeList creates a ChangeList struct based on the informed type
-func NewChangeList(ct string) *ChangeList {
-	change := &ChangeList{}
+// ChangeTypeFromString creates a type based on its string name
+func ChangeTypeFromString(ct string) ChangeType {
 	switch strings.ToLower(ct) {
 	case "added":
-		change.Type = Added
+		return Added
 	case "changed":
-		change.Type = Changed
+		return Changed
 	case "deprecated":
-		change.Type = Deprecated
+		return Deprecated
 	case "fixed":
-		change.Type = Fixed
+		return Fixed
 	case "removed":
-		change.Type = Removed
+		return Removed
 	case "security":
-		change.Type = Security
+		return Security
 	default:
+		return Unknown
+	}
+}
+
+// NewChangeList creates a ChangeList struct based on the informed type
+func NewChangeList(ct string) *ChangeList {
+	changeType := ChangeTypeFromString(ct)
+	if changeType == Unknown {
 		return nil
 	}
-	return change
+	return &ChangeList{Type: changeType}
 }
 
 // RenderItems renders all the items

--- a/chg/changetype_string.go
+++ b/chg/changetype_string.go
@@ -4,9 +4,9 @@ package chg
 
 import "strconv"
 
-const _ChangeType_name = "AddedChangedDeprecatedFixedRemovedSecurity"
+const _ChangeType_name = "UnknownAddedChangedDeprecatedFixedRemovedSecurity"
 
-var _ChangeType_index = [...]uint8{0, 5, 12, 22, 27, 34, 42}
+var _ChangeType_index = [...]uint8{0, 7, 12, 19, 29, 34, 41, 49}
 
 func (i ChangeType) String() string {
 	if i < 0 || i >= ChangeType(len(_ChangeType_index)-1) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -138,9 +138,18 @@ func (r *renderer) Heading(w io.Writer, node *blackfriday.Node, entering bool) b
 	case 3, 4: // It's a change
 		var buf bytes.Buffer
 		r.renderInline(&buf, node, entering)
+		changeName := buf.String()
 
-		r.currentChange = chg.NewChangeList(buf.String())
-		r.currentVersion.Changes = append(r.currentVersion.Changes, r.currentChange)
+		changeType := chg.ChangeTypeFromString(changeName)
+		if changeType != chg.Unknown {
+			r.currentChange = r.currentVersion.Change(changeType)
+			if r.currentChange == nil {
+				r.currentChange = chg.NewChangeList(changeName)
+				r.currentVersion.Changes = append(r.currentVersion.Changes, r.currentChange)
+			}
+		} else {
+			r.currentChange = nil
+		}
 
 		return blackfriday.SkipChildren
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -162,4 +162,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 		result := parser.Parse(input)
 		assert.Equal(t, expected, result)
 	})
+
+	t.Run("duplicated", func(t *testing.T) {
+		input := readFile(t, "duplicated")
+
+		expected := &chg.Changelog{
+			Preamble: "Simple paragraph.",
+			Versions: []*chg.Version{
+				{
+					Name: "Unreleased",
+					Link: "http://example.com/abcdef..HEAD",
+					Changes: []*chg.ChangeList{
+						{
+							Type: chg.Added,
+							Items: []*chg.Item{
+								{"Item 1"},
+								{"Item 2"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result := parser.Parse(input)
+		assert.Equal(t, expected, result)
+	})
 }

--- a/parser/testdata/duplicated.md
+++ b/parser/testdata/duplicated.md
@@ -1,0 +1,12 @@
+# Changelog
+
+Simple paragraph.
+
+## [Unreleased]
+### Added
+- Item 1
+
+### Added
+- Item 2
+
+[Unreleased]: http://example.com/abcdef..HEAD


### PR DESCRIPTION
When parsing a changelog file, merge sections who have the same name:

```markdown
### Added
- Item 1

### Added
- Item 2
```

become:

```markdown
### Added
- Item 1
- Item 2
```