### PR TITLE
Add --output optiont to write changes

### DIFF
--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -21,11 +21,7 @@ var bumpCmd = &cobra.Command{
 	Long:  "Change current Unreleased version into the new version",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readChangelog(filename)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(2)
-		}
+		input := readChangelog()
 
 		version := chg.Version{
 			Name: args[0],
@@ -37,7 +33,7 @@ var bumpCmd = &cobra.Command{
 		}
 
 		changelog := parser.Parse(input)
-		_, err = changelog.Release(version)
+		_, err := changelog.Release(version)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to bump version to %s: %s\n", args[0], err)
 			os.Exit(3)

--- a/cmd/bump.go
+++ b/cmd/bump.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"time"
@@ -39,7 +40,11 @@ var bumpCmd = &cobra.Command{
 			os.Exit(3)
 		}
 
-		changelog.Render(os.Stdout)
+		var buf bytes.Buffer
+		changelog.Render(&buf)
+		output := buf.Bytes()
+
+		writeChangelog(output)
 	},
 }
 

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"os"
 
 	"github.com/rcmachado/changelog/parser"
 	"github.com/spf13/cobra"
@@ -14,11 +13,7 @@ var fmtCmd = &cobra.Command{
 	Short: "Reformat the change log file",
 	Long:  "Reformats changelog input following keepachangelog.com spec",
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readChangelog(filename)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(2)
-		}
+		input := readChangelog()
 
 		chg := parser.Parse(input)
 

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/rcmachado/changelog/parser"
 	"github.com/spf13/cobra"
@@ -21,7 +20,7 @@ var fmtCmd = &cobra.Command{
 		chg.Render(&buf)
 		output := buf.Bytes()
 
-		fmt.Printf("%s", output)
+		writeChangelog(output)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,13 +24,15 @@ func init() {
 	flags.StringVarP(&filename, "filename", "f", "CHANGELOG.md", "Changelog file (use '-' for stdin)")
 }
 
-func readChangelog(name string) ([]byte, error) {
+func readChangelog() []byte {
+	name := filename
 	if name == "-" {
 		content, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return nil, err
+			fmt.Fprintf(os.Stderr, "%s", err)
+			os.Exit(2)
 		}
-		return content, nil
+		return content
 	}
 
 	var prefixDir string
@@ -41,13 +43,15 @@ func readChangelog(name string) ([]byte, error) {
 	}
 	filename, err := filepath.Abs(prefixDir + name)
 	if err != nil {
-		return nil, err
+		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(2)
 	}
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, err
+		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(2)
 	}
-	return content, nil
+	return content
 }
 
 // Execute the program with command-line args

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,15 +17,17 @@ var rootCmd = &cobra.Command{
 following the keepachangelog.com specification.`,
 }
 
-var filename string
+var inputFilename string
+var outputFilename string
 
 func init() {
 	flags := rootCmd.PersistentFlags()
-	flags.StringVarP(&filename, "filename", "f", "CHANGELOG.md", "Changelog file (use '-' for stdin)")
+	flags.StringVarP(&inputFilename, "filename", "f", "CHANGELOG.md", "Changelog file (use '-' for stdin)")
+	flags.StringVarP(&outputFilename, "output", "o", "-", "Output file (use '-' for stdout)")
 }
 
 func readChangelog() []byte {
-	name := filename
+	name := inputFilename
 	if name == "-" {
 		content, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
@@ -52,6 +54,32 @@ func readChangelog() []byte {
 		os.Exit(2)
 	}
 	return content
+}
+
+func writeChangelog(content []byte) {
+	if outputFilename == "-" {
+		os.Stdout.Write(content)
+		return
+	}
+
+	var prefixDir string
+	if strings.HasPrefix(outputFilename, "/") {
+		prefixDir = ""
+	} else {
+		prefixDir = "./"
+	}
+
+	filename, err := filepath.Abs(prefixDir + outputFilename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(2)
+	}
+
+	err = ioutil.WriteFile(filename, content, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(2)
+	}
 }
 
 // Execute the program with command-line args

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -14,11 +14,7 @@ var showCmd = &cobra.Command{
 	Short: "Show information about version",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		input, err := readChangelog(filename)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(2)
-		}
+		input := readChangelog()
 
 		chg := parser.Parse(input)
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -28,7 +28,7 @@ var showCmd = &cobra.Command{
 		v.RenderChanges(&buf)
 		output := buf.Bytes()
 
-		fmt.Printf("%s", output)
+		writeChangelog(output)
 	},
 }
 


### PR DESCRIPTION
Make all commands recognize a `-o/--output` option to specifify to where the output must be saved.