### PR TITLE
Enable test coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,12 @@ jobs:
       - run: go get -u github.com/golang/dep/cmd/dep
       - run: dep ensure -vendor-only
       - run: go get -u github.com/jstemmer/go-junit-report
+      - run: go get -u github.com/mattn/goveralls
       - run:
           command: |
             trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-            go test -v ./... | tee ${TEST_RESULTS}/go-test.out
+            go test -cover -race -coverprofile=${TEST_RESULTS}/coverage.out -v ./... | tee ${TEST_RESULTS}/go-test.out
+      - run: goveralls -coverprofile=${TEST_RESULTS}/coverage.out -service=circle-ci -repotoken="${COVERALLS_TOKEN}"
       - store_artifacts:
           path: /tmp/test-results
           destination: raw-test-output

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build: deps
 	go build -o changelog main.go
 
 test:
-	go test ./...
+	go test -cover ./...
 
 release: build
 	./changelog release $(V) -o CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # changelog
 
 [![CircleCI](https://circleci.com/gh/rcmachado/changelog.svg?style=svg)](https://circleci.com/gh/rcmachado/changelog)
+[![Coverage Status](https://coveralls.io/repos/github/rcmachado/changelog/badge.svg?branch=add-coverage)](https://coveralls.io/github/rcmachado/changelog?branch=add-coverage)
 [![Go Report Card](https://goreportcard.com/badge/github.com/rcmachado/changelog)](https://goreportcard.com/report/github.com/rcmachado/changelog)
 
 `changelog` is a command-line application to read and manipulate


### PR DESCRIPTION
Use [Coveralls](https://coveralls.io/) to report test coverage.

Fixes #3.