### PR TITLE
Add gometalinter to Make and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,11 @@ jobs:
             trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
             go test -cover -race -coverprofile=${TEST_RESULTS}/coverage.out -v ./... | tee ${TEST_RESULTS}/go-test.out
       - run: goveralls -coverprofile=${TEST_RESULTS}/coverage.out -service=circle-ci -repotoken="${COVERALLS_TOKEN}"
+      - run:
+          command: |
+            go get -u gopkg.in/alecthomas/gometalinter.v2
+            gometalinter.v2 --install
+            gometalinter.v2 --vendor ./...
       - store_artifacts:
           path: /tmp/test-results
           destination: raw-test-output

--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,10 @@ build: deps
 test:
 	go test -cover ./...
 
+lint:
+	[[ `which gometalinter.v2` ]] || go get -u gopkg.in/alecthomas/gometalinter.v2
+	gometalinter.v2 --install
+	gometalinter.v2 --vendor ./...
+
 release: build
 	./changelog release $(V) -o CHANGELOG.md


### PR DESCRIPTION
Run gometalinter on CI and add a `make lint` task to make it easier to run locally.

Fixes \#12.