### PR TITLE
Do not submit coverage reports on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,12 +45,12 @@ jobs:
       - attach_workspace:
           at: /go/src/github.com/rcmachado/changelog
       - run: go get -v -t -d ./...
-      - run: go build -o changelog main.go
+      - run: go build -o changelog-current main.go
       - run:
           command: |
             [[ "$CIRCLE_TAG" == "" ]] && OPTS="--snapshot"
             curl -o /tmp/goreleaser -sL https://git.io/goreleaser
-            bash /tmp/goreleaser $OPTS --release-notes <(/go/src/github.com/rcmachado/changelog/changelog -f /go/src/github.com/rcmachado/changelog/CHANGELOG.md show ${CIRCLE_TAG:-unreleased})
+            bash /tmp/goreleaser $OPTS --release-notes <(/go/src/github.com/rcmachado/changelog/changelog-current -f /go/src/github.com/rcmachado/changelog/CHANGELOG.md show ${CIRCLE_TAG:-unreleased})
       - store_artifacts:
           path: dist
           destination: builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ jobs:
           command: |
             trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
             go test -cover -race -coverprofile=${TEST_RESULTS}/coverage.out -v ./... | tee ${TEST_RESULTS}/go-test.out
-      - run: goveralls -coverprofile=${TEST_RESULTS}/coverage.out -service=circle-ci -repotoken="${COVERALLS_TOKEN}"
+      - run:
+          command: |
+            [ ! -z "${COVERALLS_TOKEN}" ] && goveralls -coverprofile=${TEST_RESULTS}/coverage.out -service=circle-ci -repotoken="${COVERALLS_TOKEN}"
       - run:
           command: |
             go get -u gopkg.in/alecthomas/gometalinter.v2


### PR DESCRIPTION
To avoid having to share secrets with forks, this PR disables the coverage report if the token is not available.