### PR TITLE
Add command 'added' to manipulate changelog

### DIFF
--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -32,6 +32,25 @@ func (c *Changelog) Version(version string) *Version {
 	return nil
 }
 
+// AddItem includes the message under the proper section of Unreleased version
+func (c *Changelog) AddItem(section ChangeType, message string) {
+	v := c.Version("Unreleased")
+	if v == nil {
+		v = &Version{Name: "Unreleased"}
+		c.Versions = append([]*Version{v}, c.Versions...)
+	}
+
+	s := v.Change(section)
+	if s == nil {
+		s = NewChangeList("Added")
+		v.Changes = append(v.Changes, s)
+	}
+	item := &Item{
+		Description: message,
+	}
+	s.Items = append(s.Items, item)
+}
+
 // Release transforms Unreleased into the version informed
 func (c *Changelog) Release(newVersion Version) (*Version, error) {
 	oldUnreleased := c.Version("Unreleased")

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -31,6 +31,16 @@ func TestChangelogVersion(t *testing.T) {
 	})
 }
 
+func TestChangelogAddItem(t *testing.T) {
+	t.Run("empty-changelog", func(t *testing.T) {
+		c := Changelog{}
+		c.AddItem(Added, "my message")
+
+		assert.NotNil(t, c.Version("Unreleased"))
+		assert.NotNil(t, c.Version("Unreleased").Change(Added))
+	})
+}
+
 func TestChangelogRelease(t *testing.T) {
 	c := Changelog{
 		Versions: []*Version{

--- a/cmd/added.go
+++ b/cmd/added.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/rcmachado/changelog/chg"
+	"github.com/rcmachado/changelog/parser"
+	"github.com/spf13/cobra"
+)
+
+var addedCmd = &cobra.Command{
+	Use:   "added",
+	Short: "Add item under 'Added' section",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		input := readChangelog()
+
+		changelog := parser.Parse(input)
+		changelog.AddItem(chg.Added, strings.Join(args, " "))
+
+		var buf bytes.Buffer
+		changelog.Render(&buf)
+		output := buf.Bytes()
+
+		writeChangelog(output)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(addedCmd)
+}


### PR DESCRIPTION
Adds a command `added` to add messages under Added section of Unreleased version in the chnagelog file.

See #13.