### PR TITLE
Refactor commands to simplify usageinput/output handling

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -21,16 +21,16 @@ var bundleCmd = &cobra.Command{
 	Short: "Bundles files containing unrelased changelog entries",
 	Long:  "Bundles multiple files that follows the changetype/file.md structure into the Unreleased version",
 	Run: func(cmd *cobra.Command, args []string) {
-		input := readChangelog()
+		var bi bytes.Buffer
+		bi.ReadFrom(inputFile)
 
-		changelog := parser.Parse(input)
-		bundleFiles(directory, input, args, changelog)
+		changelog := parser.Parse(bi.Bytes())
+		bundleFiles(directory, bi.Bytes(), args, changelog)
 
 		var buf bytes.Buffer
 		changelog.Render(&buf)
-		output := buf.Bytes()
 
-		writeChangelog(output)
+		outputFile.ReadFrom(&buf)
 	},
 }
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -22,16 +22,16 @@ func buildCommands(rootCmd *cobra.Command) {
 			Short: fmt.Sprintf("Add item under '%s' section", cmdType.String()),
 			Args:  cobra.MinimumNArgs(1),
 			Run: func(cmd *cobra.Command, args []string) {
-				input := readChangelog()
+				var bi bytes.Buffer
+				bi.ReadFrom(inputFile)
 
-				changelog := parser.Parse(input)
+				changelog := parser.Parse(bi.Bytes())
 				changelog.AddItem(cmdType, strings.Join(args, " "))
 
 				var buf bytes.Buffer
 				changelog.Render(&buf)
-				output := buf.Bytes()
 
-				writeChangelog(output)
+				outputFile.ReadFrom(&buf)
 			},
 		}
 

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -12,15 +12,14 @@ var fmtCmd = &cobra.Command{
 	Short: "Reformat the change log file",
 	Long:  "Reformats changelog input following keepachangelog.com spec",
 	Run: func(cmd *cobra.Command, args []string) {
-		input := readChangelog()
-
-		chg := parser.Parse(input)
+		var bi bytes.Buffer
+		bi.ReadFrom(inputFile)
+		changelog := parser.Parse(bi.Bytes())
 
 		var buf bytes.Buffer
-		chg.Render(&buf)
-		output := buf.Bytes()
+		changelog.Render(&buf)
 
-		writeChangelog(output)
+		outputFile.ReadFrom(&buf)
 	},
 }
 

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -25,13 +25,9 @@ It will normalize the output with the new version.
 `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		input := readChangelog()
-
 		var buf bytes.Buffer
-		release(input, args, &buf)
-		output := buf.Bytes()
-
-		writeChangelog(output)
+		release(inputFile, args, &buf)
+		outputFile.ReadFrom(&buf)
 	},
 }
 
@@ -42,7 +38,7 @@ func init() {
 	rootCmd.AddCommand(releaseCmd)
 }
 
-func release(input []byte, args []string, w io.Writer) {
+func release(input io.Reader, args []string, w io.Writer) {
 	version := chg.Version{
 		Name: args[0],
 		Date: releaseDate,
@@ -52,7 +48,10 @@ func release(input []byte, args []string, w io.Writer) {
 		version.Link = compareURL
 	}
 
-	changelog := parser.Parse(input)
+	var bi bytes.Buffer
+	bi.ReadFrom(inputFile)
+	changelog := parser.Parse(bi.Bytes())
+
 	_, err := changelog.Release(version)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create release '%s': %s\n", args[0], err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,10 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -35,9 +32,6 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-var inputFilename string
-var outputFilename string
-
 func openFileOrExit(fs *pflag.FlagSet, option string, flag int, defaultIfDash *os.File) *os.File {
 	filename, err := fs.GetString(option)
 	if err != nil {
@@ -59,66 +53,10 @@ func openFileOrExit(fs *pflag.FlagSet, option string, flag int, defaultIfDash *o
 
 func init() {
 	flags := rootCmd.PersistentFlags()
-	flags.StringVarP(&inputFilename, "filename", "f", "CHANGELOG.md", "Changelog file or '-' for stdin")
+	flags.StringP("filename", "f", "CHANGELOG.md", "Changelog file or '-' for stdin")
 	rootCmd.MarkFlagFilename("filename")
-	flags.StringVarP(&outputFilename, "output", "o", "-", "Output file or '-' for stdout")
+	flags.StringP("output", "o", "-", "Output file or '-' for stdout")
 	rootCmd.MarkFlagFilename("output")
-}
-
-func readChangelog() []byte {
-	name := inputFilename
-	if name == "-" {
-		content, err := ioutil.ReadAll(os.Stdin)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s", err)
-			os.Exit(2)
-		}
-		return content
-	}
-
-	var prefixDir string
-	if strings.HasPrefix(name, "/") {
-		prefixDir = ""
-	} else {
-		prefixDir = "./"
-	}
-	filename, err := filepath.Abs(prefixDir + name)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err)
-		os.Exit(2)
-	}
-	content, err := ioutil.ReadFile(filename)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err)
-		os.Exit(2)
-	}
-	return content
-}
-
-func writeChangelog(content []byte) {
-	if outputFilename == "-" {
-		os.Stdout.Write(content)
-		return
-	}
-
-	var prefixDir string
-	if strings.HasPrefix(outputFilename, "/") {
-		prefixDir = ""
-	} else {
-		prefixDir = "./"
-	}
-
-	filename, err := filepath.Abs(prefixDir + outputFilename)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err)
-		os.Exit(2)
-	}
-
-	err = ioutil.WriteFile(filename, content, 0644)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err)
-		os.Exit(2)
-	}
 }
 
 // Execute the program with command-line args

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,10 +22,10 @@ var rootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		fs := cmd.Flags()
 
-		fdr := openFileOrExit(fs, "filename", os.O_RDONLY)
+		fdr := openFileOrExit(fs, "filename", os.O_RDONLY, os.Stdin)
 		inputFile = bufio.NewReader(fdr)
 
-		fdw := openFileOrExit(fs, "output", os.O_WRONLY|os.O_CREATE)
+		fdw := openFileOrExit(fs, "output", os.O_WRONLY|os.O_CREATE, os.Stdout)
 		outputFile = bufio.NewWriter(fdw)
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
@@ -38,12 +38,17 @@ var rootCmd = &cobra.Command{
 var inputFilename string
 var outputFilename string
 
-func openFileOrExit(fs *pflag.FlagSet, option string, flag int) *os.File {
+func openFileOrExit(fs *pflag.FlagSet, option string, flag int, defaultIfDash *os.File) *os.File {
 	filename, err := fs.GetString(option)
 	if err != nil {
 		fmt.Printf("Failed to get option '%s': %s\n", option, err)
 		os.Exit(2)
 	}
+
+	if filename == "-" {
+		return defaultIfDash
+	}
+
 	file, err := os.OpenFile(filename, flag, 0644)
 	if err != nil {
 		fmt.Printf("Failed to open file '%s': %s\n", filename, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,9 @@ var outputFilename string
 func init() {
 	flags := rootCmd.PersistentFlags()
 	flags.StringVarP(&inputFilename, "filename", "f", "CHANGELOG.md", "Changelog file or '-' for stdin")
+	rootCmd.MarkFlagFilename("filename")
 	flags.StringVarP(&outputFilename, "output", "o", "-", "Output file or '-' for stdout")
+	rootCmd.MarkFlagFilename("output")
 }
 
 func readChangelog() []byte {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -15,11 +15,11 @@ var showCmd = &cobra.Command{
 	Long:  `Show changelog section and entries for version [version]`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		input := readChangelog()
+		var bi bytes.Buffer
+		bi.ReadFrom(inputFile)
+		changelog := parser.Parse(bi.Bytes())
 
-		chg := parser.Parse(input)
-
-		v := chg.Version(args[0])
+		v := changelog.Version(args[0])
 		if v == nil {
 			fmt.Printf("Unknown version: '%s'\n", args[0])
 			os.Exit(3)
@@ -27,9 +27,8 @@ var showCmd = &cobra.Command{
 
 		var buf bytes.Buffer
 		v.RenderChanges(&buf)
-		output := buf.Bytes()
 
-		writeChangelog(output)
+		outputFile.ReadFrom(&buf)
 	},
 }
 


### PR DESCRIPTION
Use cobra hooks such as `PersistentPreRun` and `PersistentPostRun` to simplify input/output handling.

Instead of having each command opening and closing input/output, uses cobra pre/post hooks to open and close the files.

This PR also replaces `readCHangelog` and `writeChangelog` with functions from bufio package, simplifying file handling.