### PR TITLE
Change parser.Parser interface to accept io.Reader

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -21,11 +21,8 @@ var bundleCmd = &cobra.Command{
 	Short: "Bundles files containing unrelased changelog entries",
 	Long:  "Bundles multiple files that follows the changetype/file.md structure into the Unreleased version",
 	Run: func(cmd *cobra.Command, args []string) {
-		var bi bytes.Buffer
-		bi.ReadFrom(inputFile)
-
-		changelog := parser.Parse(bi.Bytes())
-		bundleFiles(directory, bi.Bytes(), args, changelog)
+		changelog := parser.Parse(inputFile)
+		bundleFiles(directory, changelog)
 
 		var buf bytes.Buffer
 		changelog.Render(&buf)
@@ -39,7 +36,7 @@ func init() {
 	rootCmd.AddCommand(bundleCmd)
 }
 
-func bundleFiles(root string, input []byte, args []string, c *chg.Changelog) {
+func bundleFiles(root string, c *chg.Changelog) {
 	validTypes := map[string]chg.ChangeType{
 		"added":      chg.Added,
 		"changed":    chg.Changed,

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"log"
 	"os"
@@ -23,11 +22,7 @@ var bundleCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		changelog := parser.Parse(inputFile)
 		bundleFiles(directory, changelog)
-
-		var buf bytes.Buffer
-		changelog.Render(&buf)
-
-		outputFile.ReadFrom(&buf)
+		changelog.Render(outputFile)
 	},
 }
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -22,10 +22,7 @@ func buildCommands(rootCmd *cobra.Command) {
 			Short: fmt.Sprintf("Add item under '%s' section", cmdType.String()),
 			Args:  cobra.MinimumNArgs(1),
 			Run: func(cmd *cobra.Command, args []string) {
-				var bi bytes.Buffer
-				bi.ReadFrom(inputFile)
-
-				changelog := parser.Parse(bi.Bytes())
+				changelog := parser.Parse(inputFile)
 				changelog.AddItem(cmdType, strings.Join(args, " "))
 
 				var buf bytes.Buffer

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 
@@ -24,11 +23,7 @@ func buildCommands(rootCmd *cobra.Command) {
 			Run: func(cmd *cobra.Command, args []string) {
 				changelog := parser.Parse(inputFile)
 				changelog.AddItem(cmdType, strings.Join(args, " "))
-
-				var buf bytes.Buffer
-				changelog.Render(&buf)
-
-				outputFile.ReadFrom(&buf)
+				changelog.Render(outputFile)
 			},
 		}
 

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"bytes"
-
 	"github.com/rcmachado/changelog/parser"
 	"github.com/spf13/cobra"
 )
@@ -13,11 +11,7 @@ var fmtCmd = &cobra.Command{
 	Long:  "Reformats changelog input following keepachangelog.com spec",
 	Run: func(cmd *cobra.Command, args []string) {
 		changelog := parser.Parse(inputFile)
-
-		var buf bytes.Buffer
-		changelog.Render(&buf)
-
-		outputFile.ReadFrom(&buf)
+		changelog.Render(outputFile)
 	},
 }
 

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -12,9 +12,7 @@ var fmtCmd = &cobra.Command{
 	Short: "Reformat the change log file",
 	Long:  "Reformats changelog input following keepachangelog.com spec",
 	Run: func(cmd *cobra.Command, args []string) {
-		var bi bytes.Buffer
-		bi.ReadFrom(inputFile)
-		changelog := parser.Parse(bi.Bytes())
+		changelog := parser.Parse(inputFile)
 
 		var buf bytes.Buffer
 		changelog.Render(&buf)

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -25,9 +24,7 @@ It will normalize the output with the new version.
 `,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		var buf bytes.Buffer
-		release(inputFile, args, &buf)
-		outputFile.ReadFrom(&buf)
+		release(inputFile, args, outputFile)
 	},
 }
 

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -48,9 +48,7 @@ func release(input io.Reader, args []string, w io.Writer) {
 		version.Link = compareURL
 	}
 
-	var bi bytes.Buffer
-	bi.ReadFrom(inputFile)
-	changelog := parser.Parse(bi.Bytes())
+	changelog := parser.Parse(inputFile)
 
 	_, err := changelog.Release(version)
 	if err != nil {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -15,9 +15,7 @@ var showCmd = &cobra.Command{
 	Long:  `Show changelog section and entries for version [version]`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		var bi bytes.Buffer
-		bi.ReadFrom(inputFile)
-		changelog := parser.Parse(bi.Bytes())
+		changelog := parser.Parse(inputFile)
 
 		v := changelog.Version(args[0])
 		if v == nil {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 
@@ -23,10 +22,7 @@ var showCmd = &cobra.Command{
 			os.Exit(3)
 		}
 
-		var buf bytes.Buffer
-		v.RenderChanges(&buf)
-
-		outputFile.ReadFrom(&buf)
+		v.RenderChanges(outputFile)
 	},
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"regexp"
 	"strings"
 
@@ -12,10 +14,15 @@ import (
 )
 
 // Parse input into a proper Changelog struct
-func Parse(input []byte) *chg.Changelog {
+func Parse(r io.Reader) *chg.Changelog {
 	extensions := blackfriday.NoIntraEmphasis | blackfriday.Strikethrough
 	renderer := newRenderer()
 
+	input, err := ioutil.ReadAll(r)
+	if err != nil {
+		log.Fatal(err)
+		return nil
+	}
 	blackfriday.Run(input, blackfriday.WithExtensions(extensions), blackfriday.WithRenderer(&renderer))
 
 	return renderer.Result()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,8 +1,9 @@
 package parser_test
 
 import (
+	"bufio"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/rcmachado/changelog/chg"
@@ -10,13 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func readFile(t *testing.T, filename string) []byte {
-	input, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.md", filename))
+func readFile(t *testing.T, filename string) *bufio.Reader {
+	input, err := os.Open(fmt.Sprintf("testdata/%s.md", filename))
 	if err != nil {
 		t.Errorf("Failed to read testdata: %s", err)
 	}
 
-	return input
+	return bufio.NewReader(input)
 }
 
 func TestParserParse(t *testing.T) {


### PR DESCRIPTION
Avoid the need to convert to `[]byte` in every command.