### PR TITLE
Refactor fmt command to be testable

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -11,7 +11,7 @@ func NewFmtCmd(iostreams *IOStreams) *cobra.Command {
 		Short: "Reformat the change log file",
 		Long:  "Reformats changelog input following keepachangelog.com spec",
 		Run: func(cmd *cobra.Command, args []string) {
-			format(ioStreams)
+			format(iostreams)
 		},
 	}
 }

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -11,12 +11,8 @@ func NewFmtCmd(iostreams *IOStreams) *cobra.Command {
 		Short: "Reformat the change log file",
 		Long:  "Reformats changelog input following keepachangelog.com spec",
 		Run: func(cmd *cobra.Command, args []string) {
-			format(iostreams)
+			changelog := parser.Parse(iostreams.In)
+			changelog.Render(iostreams.Out)
 		},
 	}
-}
-
-func format(ioStreams *IOStreams) {
-	changelog := parser.Parse(ioStreams.In)
-	changelog.Render(ioStreams.Out)
 }

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -5,16 +5,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var fmtCmd = &cobra.Command{
-	Use:   "fmt",
-	Short: "Reformat the change log file",
-	Long:  "Reformats changelog input following keepachangelog.com spec",
-	Run: func(cmd *cobra.Command, args []string) {
-		changelog := parser.Parse(inputFile)
-		changelog.Render(outputFile)
-	},
+func NewFmtCmd(iostreams *IOStreams) *cobra.Command {
+	return &cobra.Command{
+		Use:   "fmt",
+		Short: "Reformat the change log file",
+		Long:  "Reformats changelog input following keepachangelog.com spec",
+		Run: func(cmd *cobra.Command, args []string) {
+			format(ioStreams)
+		},
+	}
 }
 
-func init() {
-	rootCmd.AddCommand(fmtCmd)
+func format(ioStreams *IOStreams) {
+	changelog := parser.Parse(ioStreams.In)
+	changelog.Render(ioStreams.Out)
 }

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormat(t *testing.T) {
+	changelog := `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+	
+## [Unreleased]
+### Changed
+- Out of order entries
+- Another item here
+
+### Added
+- Something else
+
+## [0.1.0] - 2018-06-17
+
+### Added
+
+- Command A
+- Command B
+- Command C
+
+[Unreleased]: https://github.com/rcmachado/changelog/compare/0.2.0...HEAD
+[0.1.0]: https://github.com/rcmachado/changelog/compare/ae761ff...0.1.0`
+
+	expected := `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Something else
+
+### Changed
+- Out of order entries
+- Another item here
+
+## [0.1.0] - 2018-06-17
+### Added
+- Command A
+- Command B
+- Command C
+
+[Unreleased]: https://github.com/rcmachado/changelog/compare/0.2.0...HEAD
+[0.1.0]: https://github.com/rcmachado/changelog/compare/ae761ff...0.1.0
+`
+
+	var out bytes.Buffer
+	iostreams := &IOStreams{
+		In:  strings.NewReader(changelog),
+		Out: &out,
+	}
+
+	format(iostreams)
+
+	assert.Equal(t, expected, string(out.Bytes()))
+}

--- a/cmd/fmt_test.go
+++ b/cmd/fmt_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFormat(t *testing.T) {
+func TestCmd(t *testing.T) {
 	changelog := `# Changelog
 
 All notable changes to this project will be documented in this file.
@@ -60,13 +60,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.1.0]: https://github.com/rcmachado/changelog/compare/ae761ff...0.1.0
 `
 
-	var out bytes.Buffer
+	out := new(bytes.Buffer)
 	iostreams := &IOStreams{
 		In:  strings.NewReader(changelog),
-		Out: &out,
+		Out: out,
 	}
 
-	format(iostreams)
+	fmt := NewFmtCmd(iostreams)
+	_, err := fmt.ExecuteC()
 
+	assert.Nil(t, err)
 	assert.Equal(t, expected, string(out.Bytes()))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,9 @@ func openFileOrExit(fs *pflag.FlagSet, option string, flag int, defaultIfDash *o
 func init() {
 	ioStreams = &IOStreams{}
 
+	fmtCmd := NewFmtCmd(ioStreams)
+	rootCmd.AddCommand(fmtCmd)
+
 	flags := rootCmd.PersistentFlags()
 	flags.StringP("filename", "f", "CHANGELOG.md", "Changelog file or '-' for stdin")
 	rootCmd.MarkFlagFilename("filename")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -11,6 +12,13 @@ import (
 
 var inputFile *bufio.Reader
 var outputFile *bufio.Writer
+
+var ioStreams *IOStreams
+
+type IOStreams struct {
+	In  io.Reader
+	Out io.Writer
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "changelog",
@@ -24,6 +32,9 @@ var rootCmd = &cobra.Command{
 
 		fdw := openFileOrExit(fs, "output", os.O_WRONLY|os.O_CREATE, os.Stdout)
 		outputFile = bufio.NewWriter(fdw)
+
+		ioStreams.In = inputFile
+		ioStreams.Out = outputFile
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		if outputFile != nil {
@@ -52,6 +63,8 @@ func openFileOrExit(fs *pflag.FlagSet, option string, flag int, defaultIfDash *o
 }
 
 func init() {
+	ioStreams = &IOStreams{}
+
 	flags := rootCmd.PersistentFlags()
 	flags.StringP("filename", "f", "CHANGELOG.md", "Changelog file or '-' for stdin")
 	rootCmd.MarkFlagFilename("filename")


### PR DESCRIPTION
Refactor `fmt` command to be testable and add tests.

See #27.