### PR TITLE
Add init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Use "changelog [command] --help" for more information about a command.
 Outputs a changelog with only preamble and Unreleased version to standard output. You can specify a filename using `--output/-o` flag:
 
 ```bash
-$ changelog init -o CHANGELOG.md
+$ changelog init -o CHANGELOG.md --compare-url https://github.com/rcmachado/changelog/compare/abcdef...HEAD
 Changelog file 'CHANGELOG.md' created.
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Available Commands:
   fixed       Add item under 'Fixed' section
   fmt         Reformat the change log file
   help        Help about any command
-  init        creates a new changelog file
+  init        Create a new changelog file
   release     Change Unreleased to [version]
   removed     Add item under 'Removed' section
   security    Add item under 'Security' section
@@ -65,7 +65,7 @@ Creates a new `CHANGELOG.md` file (or any other specified by `--output/-o` flag)
 
 ```bash
 $ changelog init
-Changelog file 'CHANGELOG.md' created
+Changelog file 'CHANGELOG.md' created.
 ```
 
 ### fmt

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Creates a new `CHANGELOG.md` file (or any other specified by `--output/-o` flag)
 
 ```bash
 $ changelog init
+Changelog file 'CHANGELOG.md' created
 ```
 
 ### fmt

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Available Commands:
   fixed       Add item under 'Fixed' section
   fmt         Reformat the change log file
   help        Help about any command
-  init        Create a new changelog file
+  init        Initializes a new changelog
   release     Change Unreleased to [version]
   removed     Add item under 'Removed' section
   security    Add item under 'Security' section
@@ -61,10 +61,10 @@ Use "changelog [command] --help" for more information about a command.
 
 ### init
 
-Creates a new `CHANGELOG.md` file (or any other specified by `--output/-o` flag) in the current directory:
+Outputs a changelog with only preamble and Unreleased version to standard output. You can specify a filename using `--output/-o` flag:
 
 ```bash
-$ changelog init
+$ changelog init -o CHANGELOG.md
 Changelog file 'CHANGELOG.md' created.
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,16 +31,24 @@ $ make build
 
 ## Usage
 
-```!bash
+```
 changelog manipulate and validate markdown changelog files following the keepachangelog.com specification.
 
 Usage:
   changelog [command]
 
 Available Commands:
+  added       Add item under 'Added' section
+  bundle      Bundles files containing unrelased changelog entries
+  changed     Add item under 'Changed' section
+  deprecated  Add item under 'Deprecated' section
+  fixed       Add item under 'Fixed' section
   fmt         Reformat the change log file
   help        Help about any command
+  init        creates a new changelog file
   release     Change Unreleased to [version]
+  removed     Add item under 'Removed' section
+  security    Add item under 'Security' section
   show        Show changelog for [version]
 
 Flags:
@@ -49,6 +57,14 @@ Flags:
   -o, --output string     Output file or '-' for stdout (default "-")
 
 Use "changelog [command] --help" for more information about a command.
+```
+
+### init
+
+Creates a new `CHANGELOG.md` file (or any other specified by `--output/-o` flag) in the current directory:
+
+```bash
+$ changelog init
 ```
 
 ### fmt

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -90,7 +90,7 @@ func (c *Changelog) Release(newVersion Version) (*Version, error) {
 		Name: "Unreleased",
 	}
 
-	if prevVersion == oldUnreleased && newVersion.Link == "" {
+	if (prevVersion == nil || prevVersion == oldUnreleased) && newVersion.Link == "" {
 		// we don't have a previous version
 		return nil, fmt.Errorf("Could not infer the compare link")
 	}

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -79,7 +79,12 @@ func (c *Changelog) AddItem(section ChangeType, message string) {
 // Release transforms Unreleased into the version informed
 func (c *Changelog) Release(newVersion Version) (*Version, error) {
 	oldUnreleased := c.Version("Unreleased")
-	prevVersion := c.Versions[1]
+	var prevVersion *Version
+	if len(c.Versions) > 1 {
+		prevVersion = c.Versions[1]
+	} else {
+		prevVersion = nil
+	}
 
 	newUnreleased := Version{
 		Name: "Unreleased",

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -14,9 +14,34 @@ type Changelog struct {
 	Versions []*Version
 }
 
-// NewChangelog creates the changelog struct
+// NewChangelog creates the Changelog struct
 func NewChangelog() *Changelog {
 	c := Changelog{}
+	return &c
+}
+
+// NewEmptyChangelog creates the Changelog struct with default Preamble and Unreleased section
+func NewEmptyChangelog(unreleasedCompareURL string) *Changelog {
+	c := Changelog{
+		Preamble: `All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).`,
+		Versions: []*Version{
+			{
+				Name: "Unreleased",
+				Link: unreleasedCompareURL,
+				Changes: []*ChangeList{
+					{
+						Type: Added,
+						Items: []*Item{
+							{Description: "First commit"},
+						},
+					},
+				},
+			},
+		},
+	}
 	return &c
 }
 

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -7,6 +7,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewEmptyChangelog(t *testing.T) {
+	c := NewEmptyChangelog("https://example.com/abcdef...HEAD")
+	assert.NotEmpty(t, c.Preamble)
+
+	unreleased := c.Version("Unreleased")
+	assert.NotNil(t, unreleased)
+	assert.Equal(t, unreleased.Name, "Unreleased")
+	assert.Equal(t, unreleased.Link, "https://example.com/abcdef...HEAD")
+
+	added := unreleased.Change(Added)
+	assert.NotNil(t, added)
+	assert.Equal(t, 1, len(added.Items))
+
+	assert.NotNil(t, added.Items[0])
+	assert.Equal(t, added.Items[0].Description, "First commit")
+}
+
 func TestChangelogVersion(t *testing.T) {
 	unreleased := &Version{Name: "Unreleased"}
 	v123 := &Version{Name: "1.2.3"}

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -145,6 +145,20 @@ func TestChangelogReleaseMinimal(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestChangelogReleaseFailIfNoVersionLink(t *testing.T) {
+	c := Changelog{
+		Versions: []*Version{
+			{Name: "Unreleased"},
+		},
+	}
+
+	v := Version{Name: "1.0.0"}
+	newVersion, err := c.Release(v)
+
+	assert.Nil(t, newVersion)
+	assert.Error(t, err)
+}
+
 func TestChangelogRenderLinks(t *testing.T) {
 	unreleased := &Version{Name: "Unreleased", Link: "http://example.com/unreleased"}
 	v123 := &Version{Name: "1.2.3", Link: "http://example.com/1.2.3"}

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -115,6 +115,36 @@ func TestChangelogRelease(t *testing.T) {
 	})
 }
 
+func TestChangelogReleaseMinimal(t *testing.T) {
+	c := Changelog{
+		Versions: []*Version{
+			{
+				Name: "Unreleased",
+				Link: "http://example.com/abcdef..HEAD",
+				Changes: []*ChangeList{
+					{
+						Type: Added,
+						Items: []*Item{
+							{Description: "New feature"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := Version{Name: "1.0.0", Link: "https://localhost/<prev>..<next>"}
+	newVersion, err := c.Release(v)
+
+	assert.Equal(t, "1.0.0", newVersion.Name)
+	assert.Equal(t, 1, len(newVersion.Changes))
+
+	unreleased := c.Version("Unreleased")
+	assert.Equal(t, "https://localhost/1.0.0..HEAD", unreleased.Link)
+
+	assert.Nil(t, err)
+}
+
 func TestChangelogRenderLinks(t *testing.T) {
 	unreleased := &Version{Name: "Unreleased", Link: "http://example.com/unreleased"}
 	v123 := &Version{Name: "1.2.3", Link: "http://example.com/1.2.3"}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,18 +8,19 @@ import (
 )
 
 func newInitCmd(iostreams *IOStreams) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initializes a new changelog",
 		Long: `Outputs an empty changelog, with preamble and Unreleased version
 
 You can specify a filename using the --output/-o flag.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			compareURL := "https://github.com/rcmachado/changelog/compare/abcdef...HEAD"
+			fs := cmd.Flags()
+			compareURL, _ := fs.GetString("compare-url")
+
 			c := chg.NewEmptyChangelog(compareURL)
 			c.Render(iostreams.Out)
 
-			fs := cmd.Flags()
 			destination, _ := fs.GetString("output")
 			if destination != "-" {
 				out := cmd.OutOrStdout()
@@ -27,4 +28,9 @@ You can specify a filename using the --output/-o flag.`,
 			}
 		},
 	}
+
+	cmd.Flags().StringP("compare-url", "c", "", "Set compare URL for Unreleased section")
+	cmd.MarkFlagRequired("compare-url")
+
+	return cmd
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,18 +10,21 @@ import (
 func newInitCmd(iostreams *IOStreams) *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
-		Short: "Creates a new changelog file",
-		Long: `Creates CHANGELOG.md file in the current directory
+		Short: "Initializes a new changelog",
+		Long: `Outputs an empty changelog, with preamble and Unreleased version
 
-You can specify a different filename using the --output/-o flag.`,
+You can specify a filename using the --output/-o flag.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			compareURL := "https://github.com/rcmachado/changelog/compare/abcdef...HEAD"
 			c := chg.NewEmptyChangelog(compareURL)
 			c.Render(iostreams.Out)
 
-			out := cmd.OutOrStdout()
-			filename, _ := cmd.Flags().GetString("output")
-			fmt.Fprintf(out, "Changelog file '%s' created.\n", filename)
+			fs := cmd.Flags()
+			destination, _ := fs.GetString("output")
+			if destination != "-" {
+				out := cmd.OutOrStdout()
+				fmt.Fprintf(out, "Changelog file '%s' created.\n", destination)
+			}
 		},
 	}
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,7 +9,10 @@ import (
 func newInitCmd(iostreams *IOStreams) *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
-		Short: "creates a new changelog file",
+		Short: "Creates a new changelog file",
+		Long: `Creates CHANGELOG.md file in the current directory
+
+You can specify a different filename using the --output/-o flag.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			compareURL := "https://github.com/rcmachado/changelog/compare/abcdef...HEAD"
 			c := chg.NewEmptyChangelog(compareURL)
@@ -17,7 +20,7 @@ func newInitCmd(iostreams *IOStreams) *cobra.Command {
 
 			out := cmd.OutOrStdout()
 			filename, _ := cmd.Flags().GetString("output")
-			fmt.Fprintf(out, "Changelog file '%s' created\n", filename)
+			fmt.Fprintf(out, "Changelog file '%s' created.\n", filename)
 		},
 	}
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/rcmachado/changelog/chg"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,10 @@ func newInitCmd(iostreams *IOStreams) *cobra.Command {
 			compareURL := "https://github.com/rcmachado/changelog/compare/abcdef...HEAD"
 			c := chg.NewEmptyChangelog(compareURL)
 			c.Render(iostreams.Out)
+
+			out := cmd.OutOrStdout()
+			filename, _ := cmd.Flags().GetString("output")
+			fmt.Fprintf(out, "Changelog file '%s' created\n", filename)
 		},
 	}
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/rcmachado/changelog/chg"
 	"github.com/spf13/cobra"
 )

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/rcmachado/changelog/chg"
+	"github.com/spf13/cobra"
+)
+
+func newInitCmd(iostreams *IOStreams) *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "creates a new changelog file",
+		Run: func(cmd *cobra.Command, args []string) {
+			compareURL := "https://github.com/rcmachado/changelog/compare/abcdef...HEAD"
+			c := chg.NewEmptyChangelog(compareURL)
+			c.Render(iostreams.Out)
+		},
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitCmd(t *testing.T) {
+	expected := `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- First commit
+
+[Unreleased]: https://github.com/rcmachado/changelog/compare/abcdef...HEAD
+`
+
+	out := new(bytes.Buffer)
+	iostreams := &IOStreams{
+		In:  nil,
+		Out: out,
+	}
+
+	cmd := newInitCmd(iostreams)
+	_, err := cmd.ExecuteC()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(out.Bytes()))
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -29,8 +29,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 	}
 
 	cmd := newInitCmd(iostreams)
+	cmd.SetArgs([]string{"--compare-url", "https://github.com/rcmachado/changelog/compare/abcdef...HEAD"})
 	_, err := cmd.ExecuteC()
 
 	assert.Nil(t, err)
 	assert.Equal(t, expected, string(out.Bytes()))
+}
+
+func TestInitCmdRequiresCompareURL(t *testing.T) {
+	iostreams := &IOStreams{
+		In:  nil,
+		Out: new(bytes.Buffer),
+	}
+
+	cmd := newInitCmd(iostreams)
+	_, err := cmd.ExecuteC()
+
+	assert.Error(t, err)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,9 @@ func openFileOrExit(fs *pflag.FlagSet, option string, flag int, defaultIfDash *o
 func init() {
 	ioStreams = &IOStreams{}
 
+	initCmd := newInitCmd(ioStreams)
+	rootCmd.AddCommand(initCmd)
+
 	fmtCmd := NewFmtCmd(ioStreams)
 	rootCmd.AddCommand(fmtCmd)
 


### PR DESCRIPTION
This adds a new `init` command that initializes an empty `CHANGELOG.md` file.

This also fixes an issue when the change log only had the Unreleased version defined.

Fixes #35.