### PR TITLE
Add tests for commands that manipulate changelog file

### DIFF
--- a/cmd/changetype.go
+++ b/cmd/changetype.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newManipulationCmd(iostreams *IOStreams, ct chg.ChangeType) *cobra.Command {
+func newChangeTypeCmd(iostreams *IOStreams, ct chg.ChangeType) *cobra.Command {
 	sectionName := ct.String()
 
 	return &cobra.Command{
@@ -25,7 +25,7 @@ func newManipulationCmd(iostreams *IOStreams, ct chg.ChangeType) *cobra.Command 
 
 }
 
-func newManipulationCmds(iostreams *IOStreams) []*cobra.Command {
+func newChangeTypeCmds(iostreams *IOStreams) []*cobra.Command {
 	cmdTypes := []chg.ChangeType{
 		chg.Added, chg.Changed, chg.Deprecated, chg.Fixed, chg.Removed, chg.Security,
 	}
@@ -34,7 +34,7 @@ func newManipulationCmds(iostreams *IOStreams) []*cobra.Command {
 
 	for idx, changeType := range cmdTypes {
 		cmdType := changeType
-		cmd := newManipulationCmd(iostreams, cmdType)
+		cmd := newChangeTypeCmd(iostreams, cmdType)
 		allCmds[idx] = cmd
 	}
 

--- a/cmd/changetype_test.go
+++ b/cmd/changetype_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/rcmachado/changelog/chg"
+	"github.com/rcmachado/changelog/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewChangeTypeCmd(t *testing.T) {
+	changelog, err := ioutil.ReadFile("testdata/minimal-changelog.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := new(bytes.Buffer)
+	iostreams := &IOStreams{
+		In:  bytes.NewBuffer(changelog),
+		Out: out,
+	}
+
+	cmd := newChangeTypeCmd(iostreams, chg.Security)
+	cmd.SetArgs([]string{"some", "release", "item"})
+	_, err = cmd.ExecuteC()
+
+	assert.Nil(t, err)
+
+	c := parser.Parse(out)
+	v := c.Version("Unreleased")
+
+	secChange := v.Change(chg.Security)
+	assert.NotNil(t, secChange)
+	assert.NotEmpty(t, secChange.Items)
+	assert.Equal(t, "some release item", secChange.Items[0].Description)
+}
+
+func TestNewChangeTypeCmds(t *testing.T) {
+	iostreams := &IOStreams{
+		In:  new(bytes.Buffer),
+		Out: new(bytes.Buffer),
+	}
+
+	allCmds := newChangeTypeCmds(iostreams)
+	assert.Len(t, allCmds, 6)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,7 @@ func init() {
 		newShowCmd(ioStreams),
 	)
 
-	manipulationCmds := newManipulationCmds(ioStreams)
+	manipulationCmds := newChangeTypeCmds(ioStreams)
 	for _, cmd := range manipulationCmds {
 		rootCmd.AddCommand(cmd)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,11 @@ func init() {
 		newShowCmd(ioStreams),
 	)
 
+	manipulationCmds := newManipulationCmds(ioStreams)
+	for _, cmd := range manipulationCmds {
+		rootCmd.AddCommand(cmd)
+	}
+
 	flags := rootCmd.PersistentFlags()
 	flags.StringP("filename", "f", "CHANGELOG.md", "Changelog file or '-' for stdin")
 	rootCmd.MarkFlagFilename("filename")


### PR DESCRIPTION
Refactor and add tests for commands that manipulate changelog file (`added`, `security`, etc).

See #27.