### PR TITLE
Fix release command failing when no releases exist

### DIFF
--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -159,6 +159,36 @@ func TestChangelogReleaseFailIfNoVersionLink(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestChangelogReleaseNoOvewriteCompareURL(t *testing.T) {
+	c := Changelog{
+		Versions: []*Version{
+			{
+				Name: "Unreleased",
+				Link: "http://example.com/abcdef..HEAD",
+				Changes: []*ChangeList{
+					{
+						Type: Added,
+						Items: []*Item{
+							{Description: "New feature"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v := Version{Name: "1.0.0"}
+	newVersion, err := c.Release(v)
+
+	assert.Equal(t, "1.0.0", newVersion.Name)
+	assert.Equal(t, 1, len(newVersion.Changes))
+
+	unreleased := c.Version("Unreleased")
+	assert.Equal(t, "http://example.com/1.0.0..HEAD", unreleased.Link)
+
+	assert.Nil(t, err)
+}
+
 func TestChangelogRenderLinks(t *testing.T) {
 	unreleased := &Version{Name: "Unreleased", Link: "http://example.com/unreleased"}
 	v123 := &Version{Name: "1.2.3", Link: "http://example.com/1.2.3"}

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 }
 
 func TestReleaseCmdError(t *testing.T) {
-	changelog, err := ioutil.ReadFile("testdata/minimal-changelog.md")
+	changelog, err := ioutil.ReadFile("testdata/minimal-changelog-no-url.md")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,4 +62,42 @@ func TestReleaseCmdError(t *testing.T) {
 	_, err = release.ExecuteC()
 
 	assert.Error(t, err)
+}
+
+func TestReleaseCmdNoCompareURL(t *testing.T) {
+	changelog, err := ioutil.ReadFile("testdata/minimal-changelog.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2018-06-18
+### Added
+- Item 1
+
+[Unreleased]: https://github.com/rcmachado/changelog/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/rcmachado/changelog/compare/ae761ff...0.1.0
+`
+
+	out := new(bytes.Buffer)
+	iostreams := &IOStreams{
+		In:  bytes.NewBuffer(changelog),
+		Out: out,
+	}
+
+	release := newReleaseCmd(iostreams)
+	// Missing --compare-url, as the autodetect won't work for the minimal changelog
+	release.SetArgs([]string{"0.1.0", "--release-date", "2018-06-18"})
+	_, err = release.ExecuteC()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, string(out.Bytes()))
 }

--- a/cmd/testdata/minimal-changelog-no-url.md
+++ b/cmd/testdata/minimal-changelog-no-url.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Item 1


### PR DESCRIPTION
Release command didn't work when no previous releases existed and no
compare url was supplied via -c flag even though there was a compare url
for the unreleased version.

This fix uses a regex to find and replace the correct substrings on the
existing compare url.