### PR TITLE
Fix release command when there is no previous version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Compare URL now parses versions with dots correctly
+
+## [0.4.1] - 2020-02-27
+### Fixed
+- Wrong version for blackfriday dependency
 
 ## [0.4.0] - 2020-02-27
 ### Fixed
@@ -38,7 +44,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `fmt` command to reformat changelog following the spec
 - `show` command to show a specific version
 
-[Unreleased]: https://github.com/rcmachado/changelog/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/rcmachado/changelog/compare/0.4.1...HEAD
+[0.4.1]: https://github.com/rcmachado/changelog/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/rcmachado/changelog/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/rcmachado/changelog/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/rcmachado/changelog/compare/0.1.0...0.2.0

--- a/chg/changelog.go
+++ b/chg/changelog.go
@@ -101,7 +101,7 @@ func (c *Changelog) Release(newVersion Version) (*Version, error) {
 		compareURL = strings.Replace(newVersion.Link, "<prev>", newVersion.Name, -1)
 		compareURL = strings.Replace(compareURL, "<next>", "HEAD", -1)
 	} else if prevVersion == nil || prevVersion.Link == "" {
-		r := regexp.MustCompile(`/(\w+)\.{2,3}(\w+)$`)
+		r := regexp.MustCompile(`(\w[\w\.]*?)\.{2,3}(\w[\w\.]*?)$`)
 		r.MatchString(oldUnreleased.Link)
 		matches := r.FindStringSubmatch(oldUnreleased.Link)
 		compareURL = strings.Replace(oldUnreleased.Link, matches[1], newVersion.Name, -1)

--- a/chg/changelog_test.go
+++ b/chg/changelog_test.go
@@ -189,6 +189,31 @@ func TestChangelogReleaseNoOvewriteCompareURL(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestChangelogReleaseParseLinkFromPreviousVersion(t *testing.T) {
+	c := Changelog{
+		Versions: []*Version{
+			{
+				Name: "Unreleased",
+				Link: "https://github.com/org/repo/compare/0.2.0...HEAD",
+				Changes: []*ChangeList{
+					{
+						Type: Added,
+						Items: []*Item{
+							{Description: "New feature"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	newVersion, err := c.Release(Version{Name: "1.0.0"})
+	assert.NoError(t, err)
+	assert.NotNil(t, newVersion)
+
+	assert.Equal(t, "https://github.com/org/repo/compare/0.2.0...1.0.0", newVersion.Link)
+}
+
 func TestChangelogRenderLinks(t *testing.T) {
 	unreleased := &Version{Name: "Unreleased", Link: "http://example.com/unreleased"}
 	v123 := &Version{Name: "1.2.3", Link: "http://example.com/1.2.3"}


### PR DESCRIPTION
`release` command didn't handle the compare URLs properly when there was only one version in the changelog file and the version number had dots.

This fixes #60.