### PR TITLE
Change Docker base image from scratch to debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change docker base image from `scratch` to `debian:slim`
 
 ## [0.5.0] - 2020-05-26
 ### Added

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,3 +1,3 @@
-FROM scratch
+FROM debian:slim
 COPY changelog /
 ENTRYPOINT ["/changelog"]


### PR DESCRIPTION
This will add a shell into the image - required for some CI environments such as CircleCI.