### PR TITLE
Fix archive generation in releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,5 @@
 project_name: changelog
 
-archives:
-  - format: binary
-    files:
-      - none*
-
 builds:
   - binary: changelog
     goos:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Generate compressed archives for each release
 
 ## [0.6.0] - 2020-05-28
 ### Changed


### PR DESCRIPTION
Because of a misconfiguration, the archive generation was disabled. This enables their generation again.

Fixes #72.