### PR TITLE
Add git and openssh to Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Install git and openssh on docker image
+
 ### Fixed
 - Generate compressed archives for each release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN go build -o changelog .
 
 FROM alpine:latest
 
+RUN apk add git openssh
+
 WORKDIR /app
 COPY --from=build /app/changelog /usr/local/bin/changelog
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go build -o changelog .
 
 FROM alpine:latest
 
-RUN apk add git openssh
+RUN apk add --no-cache git openssh
 
 WORKDIR /app
 COPY --from=build /app/changelog /usr/local/bin/changelog


### PR DESCRIPTION
When using this image on Circle CI the checkout step is taking too long, possibly for the lack of these tools